### PR TITLE
Create docker env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.dockerignore
+.DS_Store
+.git
+.github
+.gitignore
+.gitlab-ci.yml
+.gitmodules
+.idea
+.data
+.vscode
+Dockerfile
+Dockerfile.archive
+docker-compose.yml
+

--- a/.env
+++ b/.env
@@ -1,10 +1,14 @@
+# Environment flag
+# 'sim' - simulation using grsim
+ENVIRONMENT = "sim"
+
 # # # # # # # # # # # # #
 #       SSL VISION      #
 # # # # # # # # # # # # #
 
 SSL_VISION_MULTICAST_ADDR = 224.5.23.2
 
-# Main port used by SSL vision - tracking, detection, geometry 
+# Main port used by SSL vision - tracking, detection, geometry
 #
 # Note, If grsim is providing ssl vision,
 # this values must be 10020 as it's hardcoded into grsim.
@@ -12,14 +16,17 @@ SSL_VISION_MAIN_PORT = 10020
 
 # Port used by SSL vision for visualization frames
 #
-# Note, unclear if sll vision in grsim has this...
+# Note, unclear if ssl vision in grsim has this...
 SSL_VISION_VIZ_PORT = 11011
 
 # # # # # # # # # # # # #
 #         GRSIM         #
 # # # # # # # # # # # # #
 
-GRSIM_ADDR = 127.0.0.1
+# Docker always creates an alias with the same name as
+# the service - so `grsim` will resolve to grsim container IP.
+# For local instances of grsim, this needs to be changed.
+GRSIM_ADDR = "grsim"
 
 # Values hardcoded in grsim
 GRSIM_COMMAND_LISTEN_PORT           = 20011

--- a/.env
+++ b/.env
@@ -1,0 +1,49 @@
+# # # # # # # # # # # # #
+#       SSL VISION      #
+# # # # # # # # # # # # #
+
+SSL_VISION_MULTICAST_ADDR = 224.5.23.2
+
+# Main port used by SSL vision - tracking, detection, geometry 
+#
+# Note, If grsim is providing ssl vision,
+# this values must be 10020 as it's hardcoded into grsim.
+SSL_VISION_MAIN_PORT = 10020
+
+# Port used by SSL vision for visualization frames
+#
+# Note, unclear if sll vision in grsim has this...
+SSL_VISION_VIZ_PORT = 11011
+
+# # # # # # # # # # # # #
+#         GRSIM         #
+# # # # # # # # # # # # #
+
+GRSIM_ADDR = 127.0.0.1
+
+# Values hardcoded in grsim
+GRSIM_COMMAND_LISTEN_PORT           = 20011
+GRSIM_BLUE_STATUS_SEND_PORT         = 30011
+GRSIM_YELLOW_STATUS_SEND_PORT       = 30012
+GRSIM_SIM_CONTROLLER_SEND_PORT      = 10300
+GRSIM_BLUE_CONTROLLER_LISTEN_PORT   = 10301
+GRSIM_YELLOW_CONTROLLER_LISTEN_PORT = 10302
+
+# # # # # # # # # # # # #
+#    Game Controller    #
+# # # # # # # # # # # # #
+
+# Used by game controller to publish messages
+# (referee messages for example)
+GC_PUBLISH_ADDR = 224.5.23.1
+GC_PUBLISH_PORT = 11003
+
+# # # # # # # # # # # # #
+#         WEB UI        #
+# # # # # # # # # # # # #
+
+# SSL vision web UI
+WEB_VISION_UI_PORT = 8082
+
+# Game Controller web UI
+WEB_GC_UI_PORT     = 8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.21-alpine
+
+WORKDIR /var/controller

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM golang:1.21-alpine
 
 WORKDIR /var/controller
+
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To start the environment:
 ./scripts/compose_up.sh
 ```
 
-This will start the docker environment (in detached mode). The Seegoals controller is meade to be run from inside the container. The controller container can be entered by:
+This will start the docker environment (in detached mode). The Seegoals controller is meant to be run from inside the container. The controller container can be entered by:
 ```sh
 ./scripts/enter.sh
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,46 @@ This project uses the [SeeGoals Go standard](https://github.com/LiU-SeeGoals/wik
 
 The project can be compiled by running `/scripts/build.sh`. This generates the executable in `/build` folder.
 
-## GrSim
+## Environment
+Environment configuration cen be found in `.env`. This file is automatically loaded by the `config` package by the controller. It's strongly advised to use this file instead of hard coded solutions. Apart from the controller, the docker environment loads the `.env` file into its containers.
+
+Following are the most important environment variables:
+
+* `ENVIRONMENT` - environment flag to indicate what setup is being used
+* `SSL_VISION_MULTICAST_ADDR` - multicast IP used by SSL vision
+* `SSL_VISION_MAIN_PORT` - port used for tracking, detection, and geometry packets
+* `GRSIM_ADDR` - grsim IP address
+* `GRSIM_COMMAND_LISTEN_PORT` - grsim command listen port
+* `GC_PUBLISH_ADDR` - multicast IP used by game controller
+* `GC_PUBLISH_PORT` - publish port used by game controller
+* `WEB_VISION_UI_PORT` - port on host machine for SSL vision UI when running docker
+* `WEB_GC_UI_PORT` - port on host machine for game controller UI when running docker
+
+## Docker environment
+The docker environment should be used for local development. It uses grsim to simulate the game.
+
+To start the environment:
+```sh
+./scripts/compose_up.sh
+```
+
+This will start the docker environment (in detached mode). The Seegoals controller is meade to be run from inside the container. The controller container can be entered by:
+```sh
+./scripts/enter.sh
+```
+
+Taking down the environment is done with
+```sh
+./scripts/compose_down.sh
+```
+
+Note, since the Seegoals controller and grsim run in different containers, grsim is **not** reachable at `127.0.0.1`. Instead, you should set `GRSIM_ADDR = "grsim"` in `.env`.
+
+(Docker creates aliases for containers in the same network, so `"grsim"` will resolve to the grsim container IP.)
+
+## Simulation
+Seegoals uses **grsim** for game simulation. It's possible to run grsim in headless mode (no UI) by using the docker environment.
+
 ### Actions
 Send actions to GrSim by using AddActions() owned by GrsimClient. AddActions takes a slice of actions, ordered by robot id, and translates the action to parameters accepted by GrSim.
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,0 @@
-{
-    "grSimAddress": "127.0.0.1:20011",
-    "sslClientAddress": "224.5.23.2:10020"
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,9 +65,5 @@ services:
   #  networks:
   #    - simulation
 
-volumes:
-  grafana_data:
-  influxdb_data:
-
 networks:
   simulation:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - grsim
 
   ssl-game-controller:
-    image: robocupssl/ssl-game-controller
+    image: robocupssl/ssl-game-controller:latest
     command:
       - "-visionAddress"
       - "${SSL_VISION_MULTICAST_ADDR}:${SSL_VISION_MAIN_PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,11 +38,21 @@ services:
 
   grsim:
     image: robocupssl/grsim:latest
+    # Uncomment to enable grsim UI via vnc:
+    #command: vnc
+    environment:
+      - VNC_PASSWORD=vnc
+      - VNC_GEOMETRY=1280x1024
     networks:
       - simulation
+    ports:
+      # vnc port
+      - "5900:5900"
 
   controller:
     build: .
+    env_file:
+      - .env
     volumes:
       - ./:/var/controller
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+version: '3.5'
+
+services:
+
+  ssl-vision-client:
+    image: robocupssl/ssl-vision-client:latest
+    command:
+      - "-visionAddress"
+      - "${SSL_VISION_MULTICAST_ADDR}:${SSL_VISION_MAIN_PORT}"
+      - "-visualizationAddress"
+      - "${SSL_VISION_MULTICAST_ADDR}:${SSL_VISION_VIZ_PORT}"
+      - "-address"
+      - ":${WEB_VISION_UI_PORT}"
+    ports:
+      - "${WEB_VISION_UI_PORT}:${WEB_VISION_UI_PORT}"
+    networks:
+      - simulation
+    depends_on:
+      - grsim
+
+  ssl-game-controller:
+    image: robocupssl/ssl-game-controller
+    command:
+      - "-visionAddress"
+      - "${SSL_VISION_MULTICAST_ADDR}:${SSL_VISION_MAIN_PORT}"
+      - "-trackerAddress"
+      - "${SSL_VISION_MULTICAST_ADDR}:${SSL_VISION_MAIN_PORT}"
+      - "-publishAddress"
+      - "${GC_PUBLISH_ADDR}:${GC_PUBLISH_PORT}"
+      - "-address"
+      - ":${WEB_GC_UI_PORT}"
+    ports:
+      - "${WEB_GC_UI_PORT}:${WEB_GC_UI_PORT}"
+    networks:
+      - simulation
+    depends_on:
+      - grsim
+
+  grsim:
+    image: robocupssl/grsim:latest
+    networks:
+      - simulation
+
+  controller:
+    build: .
+    volumes:
+      - ./:/var/controller
+    tty: true
+    networks:
+      - simulation
+
+  #ssl-status-board:
+  #  image: robocupssl/ssl-status-board:latest
+  #  command: -refereeAddress 224.5.23.1:11003
+  #  ports:
+  #    - "8084:8082"
+  #  networks:
+  #    - simulation
+
+  #ssl-game-controller:
+  #  image: bobrik/socat:latest
+  #  command: 'TCP4-LISTEN:8083,fork TCP4:simulator:50543'
+  #  ports:
+  #    - "8083:8083"
+  #  networks:
+  #    - simulation
+
+volumes:
+  grafana_data:
+  influxdb_data:
+
+networks:
+  simulation:

--- a/examples/example_base_station_client.go
+++ b/examples/example_base_station_client.go
@@ -9,12 +9,10 @@ import (
 
 	"github.com/LiU-SeeGoals/controller/internal/action"
 	"github.com/LiU-SeeGoals/controller/internal/client"
+	"github.com/LiU-SeeGoals/proto-messages/robot_action"
 	"gonum.org/v1/gonum/mat"
 	"google.golang.org/protobuf/proto"
-
-	"github.com/LiU-SeeGoals/controller/internal/proto/robot_action"
 )
-
 
 func main() {
 	var port int = 25565
@@ -23,16 +21,16 @@ func main() {
 }
 
 func sendPacket(port int) {
-	BaseStationClient := client.NewBaseStationClient("127.0.0.1:"+strconv.Itoa(port))
+	BaseStationClient := client.NewBaseStationClient("127.0.0.1:" + strconv.Itoa(port))
 	BaseStationClient.Init()
 
 	// Creates 2 random actions to send
 	actions := []action.Action{
 		&action.Stop{Id: 2},
 		&action.Move{
-			Id: 3,
-			Pos: mat.NewVecDense(3, []float64{100, 200, math.Pi}),
-			Goal: mat.NewVecDense(3, []float64{300, 400, -math.Pi}),
+			Id:   3,
+			Pos:  mat.NewVecDense(3, []float64{100, 200, math.Pi}),
+			Dest: mat.NewVecDense(3, []float64{300, 400, -math.Pi}),
 		},
 	}
 
@@ -67,6 +65,6 @@ func startServer(port int) {
 			fmt.Printf("Some error  %v", err)
 			continue
 		}
-		
+
 	}
 }

--- a/examples/example_ssl_vision.go
+++ b/examples/example_ssl_vision.go
@@ -3,8 +3,8 @@ package examples
 import (
 	"fmt"
 
-	"github.com/LiU-SeeGoals/controller/internal/proto/ssl_vision"
 	"github.com/LiU-SeeGoals/controller/internal/receiver"
+	"github.com/LiU-SeeGoals/proto-messages/ssl_vision"
 )
 
 func SSLVisionExample() {

--- a/examples/send_sample_action.go
+++ b/examples/send_sample_action.go
@@ -8,21 +8,19 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
-
 func sendSampleAction() {
-	BaseStationClient  := client.NewBaseStationClient("127.0.0.1:25565")
-
+	BaseStationClient := client.NewBaseStationClient("127.0.0.1:25565")
 
 	actions := []action.Action{
 		&action.Stop{Id: 2},
 		&action.Move{
-			Id: 3,
-			Pos: mat.NewVecDense(3, []float64{100, 200, math.Pi}), // Example values for Pos
+			Id:   3,
+			Pos:  mat.NewVecDense(3, []float64{100, 200, math.Pi}),  // Example values for Pos
 			Dest: mat.NewVecDense(3, []float64{300, 400, -math.Pi}), // Example values for Goal
 		},
 	}
 
-		// Create a list of actions with different robot IDs
+	// Create a list of actions with different robot IDs
 
-	BaseStationClient.Send(actions)
+	BaseStationClient.SendActions(actions)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,11 @@ require (
 )
 
 require (
+	github.com/caarlos0/env/v10 v10.0.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
+)
+
+require (
 	github.com/LiU-SeeGoals/proto-messages v0.1.0
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/LiU-SeeGoals/proto-messages v0.1.0 h1:Z8TjHJVX2uYEvOmYWf+yZCx2xR5pgArVOwY8R2mQfHs=
 github.com/LiU-SeeGoals/proto-messages v0.1.0/go.mod h1:xiDya6yIj+zx+6yOR9vIk77aKX0Z3qmwUUW+h2jiP70=
+github.com/caarlos0/env/v10 v10.0.0 h1:yIHUBZGsyqCnpTkbjk8asUlx6RFhhEs+h7TOBdgdzXA=
+github.com/caarlos0/env/v10 v10.0.0/go.mod h1:ZfulV76NvVPw3tm591U4SwL3Xx9ldzBP9aGxzeN7G18=
 github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 h1:XBBHcIb256gUJtLmY22n99HaZTz+r2Z51xUPi01m3wg=
 github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203/go.mod h1:E1jcSv8FaEny+OP/5k9UxZVw9YFWGj7eI4KR/iOBqCg=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -8,6 +10,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
 golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=

--- a/scripts/compose_build.sh
+++ b/scripts/compose_build.sh
@@ -1,6 +1,6 @@
-# Take down docker environment 
+# Build docker environment
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SRC_DIR="${SCRIPT_DIR}/../"
 
-cd $SRC_DIR && COMPOSE_PROJECT_NAME=seegoals docker compose down
+cd $SRC_DIR && COMPOSE_PROJECT_NAME=seegoals docker compose build

--- a/scripts/compose_down.sh
+++ b/scripts/compose_down.sh
@@ -1,0 +1,4 @@
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SRC_DIR="${SCRIPT_DIR}/../"
+
+cd $SRC_DIR && COMPOSE_PROJECT_NAME=seegoals docker compose down

--- a/scripts/compose_down.sh
+++ b/scripts/compose_down.sh
@@ -1,3 +1,5 @@
+# Take docker down environment 
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SRC_DIR="${SCRIPT_DIR}/../"
 

--- a/scripts/compose_up.sh
+++ b/scripts/compose_up.sh
@@ -1,0 +1,4 @@
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SRC_DIR="${SCRIPT_DIR}/../"
+
+cd $SRC_DIR && COMPOSE_PROJECT_NAME=seegoals docker compose up -d

--- a/scripts/compose_up.sh
+++ b/scripts/compose_up.sh
@@ -1,3 +1,5 @@
+# Start docker environment in detached mode
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SRC_DIR="${SCRIPT_DIR}/../"
 

--- a/scripts/enter.sh
+++ b/scripts/enter.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Enter development continer
+
+if [[ $OSTYPE =~ ^msys || $OSTYPE =~ ^win ]]; then
+    # NOTE: Not tested on windows
+    # Use 'winpty' to start an interactive shell in the container
+    winpty docker exec -it seegoals_controller_1 sh
+else
+    docker exec -it seegoals_controller_1 sh
+fi


### PR DESCRIPTION
Adds a docker environment with the following:

* grsim container
* controller container
* game controller container
* ssl vision ui container

Our controller can be run inside the controller container. Added scripts: `compose_up.sh`, `compose_down.sh`, `enter.sh`

Grsim runs in headless mode (no UI) so use ssl vision web UI instead  - `localhost:8082` by default.

Game controller can be found at `localhost:8081`.

To make this work a bit more smoothly I've added a `.env` file. This is used to make a bit of magic happen in the `docker-compose.yml` file. I also made it so that our `config` package parses this file. That means I killed `config.json`.